### PR TITLE
gradual improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,82 +4,39 @@ User account for 6-BM-A using ipython
 
 ## Installation of BlueSky control system
 
-### Install with _conda_
-
-Install bluesky core packages first
-
-> As of 04/17/2019, python3.6 is the prefered version for running BlueSky.
+It is __highly recommended__ to deploy this control system in a virtual environemnt. For example:
 
 ```bash
-conda install bluesky -c lightsource2-tag
+conda create -n bluesky
 ```
 
-then the apstools dependencies
+Switch to the new env 
 
 ```bash
-conda install pyresttable -c prjemian
+conda activate bluesky
 ```
 
-followed by installing apstools
+to install `BlueSky` core packages with
 
 ```bash
-conda install apstools -c aps-anl-dev
+conda install -c conda-forge bluesky
 ```
 
-Before installing the metapackage `jupyter`, it is recommended to pin the package `tornado` to an older version until BlueSky dev team solve the related [issue#1062](https://github.com/NSLS-II/bluesky/issues/1062).
-To do so, create a file named __pinned__ under the directory `CONDA_INSTALL_DIR/env/ENVNAME/conda-meta` with the following content:
+then the `apstools` packages for APS devices.
 
-```bash
-tornado<5
 ```
-
-Then install `jupyter` and `matplotlib` with
-
-```bash
-conda install jupyter matplotlib
-```
-
-For update BlueSky packages, one can always do update with explicit channel name
-
-```bash
-conda update bluesky -c lightsource2-tag
-```
-
-Alternatively, a package configuration file `.condarc` can be placed under `HOME` (single env) or `CONDA_INSTALL_DIR/envs/ENV_NAME` (multi-env) with the following content
-
-```YAML  
-channels:
-    - lightsource2-tag  
-    - lightsource2-dev  
-    - aps-anl-tag  
-    - aps-anl-dev  
-    - prjemian  
-    - defaults  
-    - conda-forge
-```
-
-> NOTE:
-> This is the recommended way to install BlueSky and associated dependencies.
-
-### Install with _pip_
-
-Install bluesky and apstools with pip
-
-```bash
-pip install -U pip
-pip install boltons mongoquery pims pyepics pyRestTable tzlocal jupyter suitcase matplotlib
-pip install git+https://github.com/Nikea/historydict#egg=historydict \
-            git+https://github.com/NSLS-II/amostra#egg=amostra \
-            git+https://github.com/NSLS-II/bluesky#egg=bluesky \
-            git+https://github.com/NSLS-II/databroker#egg=databroker \
-            git+https://github.com/NSLS-II/doct#egg=doct \
-            git+https://github.com/NSLS-II/event-model#egg=event_model \
-            git+https://github.com/NSLS-II/ophyd#egg=ophyd \
-            git+https://github.com/NSLS-II/hklpy#egg=hklpy
 pip install apstools
 ```
 
-Similarly, the package `tornado` need to be downgrade below 5.0 to avoid the runtime error.
+> Due to the hybrid installation source, some packages might be installed via both `conda` and `pip`.
+This is typically not an issue as the latest version should be the same regardless the source.
+However, it is recommended to check the acutal packages being used via `IPython` session should any issue occur.
+
+Some supplementary packages recommended:
+
+```bash
+conda install jupyter jupyterlab
+```
 
 ## Config Meta-data handler (MongoDB)
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,60 @@ Issue the following command in the terminal to run IPython with pre-configured e
 >> ipython --profile=s6bm
 ```
 
+By default, all devices are initialized to 'debug' mode where only simulated devices are connected.
+To check the current mode, simply do
+
+```bash
+>> mode
+```
+
+or switch to different model with
+
+```bash
+>> mode.set('production')
+```
+
+Currently there are three modes available:
+
+|     |     |
+| --- | --- |
+|__debug__| only connect to simulated ophyd devices |
+|__dryrun__| connect to real devices (PVs) and a simulated shutter |
+|__production__| production mode, ready for data collection|
+
+### Run tomo experiment
+
+The details of a tomography experiment should be specified in a YAML file (see configs/tomo_6bma.yml) for example.
+To run the experiment once, one can simply type
+
+```bash
+>> RE(tomo_scan('my_tomo_exp.yml'))
+```
+
+If you would like to modify certain field on the fly, you can also load the YAML as dictionary using 
+
+```bash
+>> tomo_exp = load_config('my_tomo_exp.yml')
+```
+
+and directly modify different entries in the dict.
+Then you can pass the dict to _RE_ to run.
+
+For example, let's say that we want the first experiment to be a step scan using _tiff_ as output and the second one using fly scan with _HDF5_ as output.
+The following code should work
+
+```bash
+>> mode.set('production')
+>> tomo_exp = load_config('my_tomo_exp.yml')
+>> tomo_exp['tomo']['type'] = 'step'
+>> tomo_exp['output']['type'] = 'tiff'
+>> RE(tomo_scan(tomo_exp))
+...
+>> tomo_exp['tomo']['type'] = 'fly'
+>> tomo_exp['output']['type'] = 'hdf'
+>> RE(tomo_scan(tomo_exp))
+```
+
 ## Dev note
 
 * Branch v0.01 was developed using standard signal staging and tested.

--- a/README.md
+++ b/README.md
@@ -56,23 +56,30 @@ The environment var `IPYTHONDIR` needs to be set where the profile folder is, or
 
 ### Startup
 
-Issue the following command in the terminal to run IPython with pre-configured environment for Tomo-characterization at 6-BM-A:
+First, activate the BlueSky env if not already
+
+```bash
+>> conda activate bluesky
+```
+
+Then, issue the following command in the terminal to run IPython with pre-configured environment for Tomo-characterization at 6-BM-A:
 
 ```bash
 >> ipython --profile=s6bm
 ```
 
 By default, all devices are initialized to 'debug' mode where only simulated devices are connected.
+
 To check the current mode, simply do
 
 ```bash
 >> mode
 ```
 
-or switch to different model with
+or directly switch to different model with
 
 ```bash
->> mode.set('production')
+>> mode.set(MODE_NAME)
 ```
 
 Currently there are three modes available:
@@ -85,14 +92,14 @@ Currently there are three modes available:
 
 ### Run tomo experiment
 
-The details of a tomography experiment should be specified in a YAML file (see configs/tomo_6bma.yml) for example.
+The details of a tomography experiment should be specified in a YAML file (see `configs/tomo_6bma.yml` for example).
 To run the experiment once, one can simply type
 
 ```bash
 >> RE(tomo_scan('my_tomo_exp.yml'))
 ```
 
-If you would like to modify certain field on the fly, you can also load the YAML as dictionary using 
+If you would like to modify certain field interactively, you can also load the YAML as dictionary using 
 
 ```bash
 >> tomo_exp = load_config('my_tomo_exp.yml')
@@ -106,16 +113,21 @@ The following code should work
 
 ```bash
 >> mode.set('production')
+...# some other prep work before running
 >> tomo_exp = load_config('my_tomo_exp.yml')
 >> tomo_exp['tomo']['type'] = 'step'
 >> tomo_exp['output']['type'] = 'tiff'
 >> RE(tomo_scan(tomo_exp))
-...
+...# some cleaning up for the first experiment 
 >> tomo_exp['tomo']['type'] = 'fly'
 >> tomo_exp['output']['type'] = 'hdf'
 >> RE(tomo_scan(tomo_exp))
+...# some cleaning up for the second experiment
 ```
 
 ## Dev note
 
 * Branch v0.01 was developed using standard signal staging and tested.
+* Current master branch uses a empty stage_sigs to by pass the staging.
+* If the experiment has to be aborted `RE.abort()` due to various reason, you can use `resume_motors_position()` to move motors back to the posiiton before the experiment.
+* To avoid namespace contamination, please use `list_predefined_vars()` and `list_predefined_func()` to check the predefined vars and functions.

--- a/configs/tomo_6bma.yml
+++ b/configs/tomo_6bma.yml
@@ -12,12 +12,12 @@ tomo:
     samX:  -1             # mm (relative position to initial position)
     samY:   0             # mm (relative position to initial position)
     preci: -180           # degree, rotation (absoute position)
-  acquire_time:   0.10    # sec
-  acquire_period: 0.11    # sec, acquire_time+0.01, (not being used in fly)
+  acquire_time:   0.050    # sec
+  acquire_period: 0.1    # sec, acquire_time+0.01, (not being used in fly)
   omega_step:     0.2     # degree
   omega_start:  -180.0    # degree
-  omega_end:    -160.0    # degree
-  n_frames:       1       # 5 frames -> 1 images
+  omega_end:     180.0    # degree
+  n_frames:       5       # 5 frames -> 1 images
   # below are for fly_scan only
   ROT_STAGE_FAST_SPEED:       1   # degree/second,
   accl:                       3   # second,

--- a/ipython_profiles/profile_s6bm/startup/01-devices.py
+++ b/ipython_profiles/profile_s6bm/startup/01-devices.py
@@ -63,10 +63,10 @@ def get_motors(mode="debug"):
     elif mode.lower() == 'debug':
         tomostage = MotorBundle(name="tomostage")
         tomostage.preci = sim.motor
-        tomostage.samX = sim.motor
+        tomostage.samX  = sim.motor
         tomostage.ksamX = sim.motor
         tomostage.ksamZ = sim.motor
-        tomostage.samY = sim.motor
+        tomostage.samY  = sim.motor
     else:
         raise ValueError(f"🙉: invalide mode, {mode}")
     return tomostage

--- a/ipython_profiles/profile_s6bm/startup/01-devices.py
+++ b/ipython_profiles/profile_s6bm/startup/01-devices.py
@@ -220,9 +220,13 @@ def get_detector(mode='debug', ADPV_prefix = "1idPG2"):
         epics.caput(f"{ADPV_prefix}:cam1:FrameType_RBV.TWST", "/exchange/data_white_post")
         epics.caput(f"{ADPV_prefix}:cam1:FrameType_RBV.THST", "/exchange/data_dark")
         # set the layout file for cam
-        det.cam.nd_attributes_file.put(str(Path('PG2_attributes.xml').absolute()))
+        # NOTE: use the __file__ as anchor should resolve the directory issue.
+        _current_fp = str(Path(__file__).parent.absolute())
+        _attrib_fp = os.path.join(_current_fp, '../../../configs/PG2_attributes.xml')
+        det.cam.nd_attributes_file.put(_attrib_fp)
         # set attributes for HDF5 plugin
-        det.hdf1.xml_file_name.put(str(Path('tomo6bma_layout.xml').absolute()))
+        _layout_fp = os.path.join(_current_fp, '../../../configs/tomo6bma_layout.xml')
+        det.hdf1.xml_file_name.put(_layout_fp)
         # turn off the problematic auto setting in cam
         det.cam.auto_exposure_auto_mode.put(0)  
         det.cam.sharpness_auto_mode.put(0)

--- a/ipython_profiles/profile_s6bm/startup/02-init.py
+++ b/ipython_profiles/profile_s6bm/startup/02-init.py
@@ -8,7 +8,7 @@ class RuntimeMode():
         self.set(mode='debug')
 
     def __repr__(self):
-        return f"Current runtime mode is set to: {self._mode}"
+        return f"Current runtime mode is set to: {self._mode} ['debug', 'dryrun', 'production']"
 
     def set(self, mode='debug', config=None):
         """
@@ -42,14 +42,17 @@ class RuntimeMode():
         # some quick sanity check production mode
         import apstools.devices as APS_devices
         aps = APS_devices.ApsMachineParametersDevice(name="APS")
-        if mode.lower() in ['production', 'dryrun']:
+        suspend_A_shutter = SuspendFloor(A_shutter.pss_state, 1)
+        """
+        if mode.lower() in ['production']:
             if aps.inUserOperations and (instrument_in_use() in (1, "6-BM-A")) and (not hutch_light_on()):
-                suspend_A_shutter = SuspendFloor(A_shutter.pss_state, 1)
+                
                 RE.install_suspender(suspend_A_shutter)
             else:
                 raise ValueError("Cannot be in production mode!")
         else:
             pass
+            """
 
         # TODO:
         # initialize all values in the dictionary

--- a/ipython_profiles/profile_s6bm/startup/02-init.py
+++ b/ipython_profiles/profile_s6bm/startup/02-init.py
@@ -52,7 +52,7 @@ class RuntimeMode():
                 raise ValueError("Cannot be in production mode!")
         else:
             pass
-            """
+        """
 
         # TODO:
         # initialize all values in the dictionary

--- a/ipython_profiles/profile_s6bm/startup/02-init.py
+++ b/ipython_profiles/profile_s6bm/startup/02-init.py
@@ -1,47 +1,63 @@
 print(f'Enter {__file__}...')
 # ----- generalized initialization ----- #
-keywords_func['init_tomo'] = '(Re)-initialized all devices with given mode'
-def init_tomo(mode='debug', config=None):
-    """
-    (Re)-initialize all devices based on given mode
+
+class RuntimeMode():
+
+    def __init__(self):
+        self._mode = 'debug'
+        self.set(mode='debug')
+
+    def __repr__(self):
+        return f"Current runtime mode is set to: {self._mode}"
+
+    def set(self, mode='debug', config=None):
+        """
+        (Re)-initialize all devices based on given mode
         simulated devices <-- debug
         actual devices    <-- dryrun, production
-    """
-    global A_shutter
-    global suspend_A_shutter
-    global tomostage
-    global preci, samX, ksamX, ksamZ, samY 
-    global psofly
-    global det
-
-    # re-init all tomo related devices
-    A_shutter = get_shutter(mode=mode)
-    tomostage = get_motors(mode=mode) 
-    preci = tomostage.preci              
-    samX = tomostage.samX               
-    ksamX = tomostage.ksamX
-    ksamZ = tomostage.ksamZ        
-    samY = tomostage.samY               
-    psofly = get_fly_motor(mode=mode)
-    det = get_detector(mode=mode)
-
-    # some quick sanity check production mode
-    import apstools.devices as APS_devices
-    aps = APS_devices.ApsMachineParametersDevice(name="APS")
-    if mode.lower() in ['production', 'dryrun']:
-        if aps.inUserOperations and (instrument_in_use() in (1, "6-BM-A")) and (not hutch_light_on()):
-            suspend_A_shutter = SuspendFloor(A_shutter.pss_state, 1)
-            RE.install_suspender(suspend_A_shutter)
+        """
+        if mode.lower() not in ['debug', 'dryrun', 'production']:
+            raise ValueError(f"Unknown mode: {mode}")
         else:
-            raise ValueError("Cannot be in production mode!")
-    else:
-        pass
+            self._mode = mode
+        
+        global A_shutter
+        global suspend_A_shutter
+        global tomostage
+        global preci, samX, ksamX, ksamZ, samY 
+        global psofly
+        global det
 
-    # TODO:
-    # initialize all values in the dictionary
+        # re-init all tomo related devices
+        A_shutter = get_shutter(mode=mode)
+        tomostage = get_motors(mode=mode) 
+        preci     = tomostage.preci              
+        samX      = tomostage.samX               
+        ksamX     = tomostage.ksamX
+        ksamZ     = tomostage.ksamZ        
+        samY      = tomostage.samY               
+        psofly    = get_fly_motor(mode=mode)
+        det       = get_detector(mode=mode)
+
+        # some quick sanity check production mode
+        import apstools.devices as APS_devices
+        aps = APS_devices.ApsMachineParametersDevice(name="APS")
+        if mode.lower() in ['production', 'dryrun']:
+            if aps.inUserOperations and (instrument_in_use() in (1, "6-BM-A")) and (not hutch_light_on()):
+                suspend_A_shutter = SuspendFloor(A_shutter.pss_state, 1)
+                RE.install_suspender(suspend_A_shutter)
+            else:
+                raise ValueError("Cannot be in production mode!")
+        else:
+            pass
+
+        # TODO:
+        # initialize all values in the dictionary
+
+mode = RuntimeMode()
 
 print(f"""
-🙊: Use init_tomo() to toggle between
+🙊: Use mode.set(mode=) to toggle between
     debug :     development mode, no hardware connection
     dryrun:     testing mode, connect to hardware, no beam
     production: ready for experiment

--- a/ipython_profiles/profile_s6bm/startup/03-plans.py
+++ b/ipython_profiles/profile_s6bm/startup/03-plans.py
@@ -145,7 +145,7 @@ def tomo_scan(config_exp):
             yield from bps.mv(
                 psofly.start,           config['tomo']['omega_start'],
                 psofly.end,             config['tomo']['omega_end'],
-                psofly.scan_delta,      config['tomo']['omega_step'],
+                psofly.scan_delta,      abs(config['tomo']['omega_step']),
                 psofly.slew_speed,      slew_speed,
             )
             # taxi

--- a/ipython_profiles/profile_s6bm/startup/03-plans.py
+++ b/ipython_profiles/profile_s6bm/startup/03-plans.py
@@ -62,7 +62,7 @@ def tomo_scan(config_exp):
         det.tiff1.enable.put(0)
         det.hdf1.enable.put(1)
     else:
-        raise ValueError(f"Unsupported output type {output_dict['type']}")
+        raise ValueError(f"Unsupported output type {config['output']['type']}")
 
     # step 1: define the scan generator
     @bpp.stage_decorator([det])

--- a/ipython_profiles/profile_s6bm/startup/03-plans.py
+++ b/ipython_profiles/profile_s6bm/startup/03-plans.py
@@ -37,7 +37,7 @@ def tomo_scan(config_exp):
     init_motors_pos['samY' ] = samY.position
     init_motors_pos['preci'] = preci.position
     _RE_abort = RE.abort
-    RE.abort = lambda : customize_abort
+    RE.abort = customize_abort
 
     # step 0: preparation
     acquire_time = config['tomo']['acquire_time']
@@ -76,19 +76,19 @@ def tomo_scan(config_exp):
         #1-1.5 configure output plugins     edited by Jason 07/19/2019
         for me in [det.tiff1, det.hdf1]:
             yield from bps.mv(me.file_path, fp)
-            yield from bps.mv(me.file_name. fn)
-            yield from bps.mv(me.file_write_mode, 'stream')
+            yield from bps.mv(me.file_name, fn)
+            yield from bps.mv(me.file_write_mode, 2)
             yield from bps.mv(me.num_capture, total_images)
-            yield from bps.mv(me.file_template, ".".join([r"%s%s_%06d",config['output']['type'].lower()]))
-            yield from bps.mv(me.capture, 1)    
-        
-        #should we set both output handle to off/0 to initialize?
+            yield from bps.mv(me.file_template, ".".join([r"%s%s_%06d",config['output']['type'].lower()]))    
+
         if config['output']['type'] in ['tif', 'tiff']:
             yield from bps.mv(det.tiff1.enable, 1)
+            yield from bps.mv(det.tiff1.capture, 1)
             yield from bps.mv(det.hdf1.enable, 0)
         elif config['output']['type'] in ['hdf', 'hdf1', 'hdf5']:
             yield from bps.mv(det.tiff1.enable, 0)
             yield from bps.mv(det.hdf1.enable, 1)
+            yield from bps.mv(det.hdf1.capture, 1)
         else:
             raise ValueError(f"Unsupported output type {output_dict['type']}")
 

--- a/ipython_profiles/profile_s6bm/startup/03-plans.py
+++ b/ipython_profiles/profile_s6bm/startup/03-plans.py
@@ -9,14 +9,15 @@ import bluesky.preprocessors as bpp
 import bluesky.plan_stubs    as bps
 from bluesky.simulators import summarize_plan
 
+keywords_vars['init_motors_pos'] = 'dict with cached motor position'
 init_motors_pos = {
     'samX':  samX.position,
     'samY':  samY.position,
     'preci': preci.position,
 }
 
-def customize_abort():
-    RE.abort()
+keywords_func['resume_motors_position'] = 'Move motors back to init position'
+def resume_motors_position():
     samX.mv( init_motors_pos['samX' ])
     samY.mv( init_motors_pos['samY' ])
     preci.mv(init_motors_pos['preci'])
@@ -33,11 +34,10 @@ def tomo_scan(config_exp):
     """
     config = load_config(config_exp) if type(config_exp) != dict else config_exp
 
+    # update the cached motor position in the dict in case exp goes wrong
     init_motors_pos['samX' ] = samX.position
     init_motors_pos['samY' ] = samY.position
     init_motors_pos['preci'] = preci.position
-    _RE_abort = RE.abort
-    RE.abort = customize_abort
 
     # step 0: preparation
     acquire_time = config['tomo']['acquire_time']

--- a/ipython_profiles/profile_s6bm/startup/03-plans.py
+++ b/ipython_profiles/profile_s6bm/startup/03-plans.py
@@ -206,4 +206,15 @@ def tomo_scan(config_exp):
 
     return (yield from scan_closure())
 
+
+keywords_func['repeat_exp'] = 'repeat given experiment n times'
+def repeat_exp(plan_func, n=1):
+    """
+    Quick wrapper to repeat certain experiment, e.g.
+    >> RE(repeat_exp(tomo_scan('tomo_scan_config.yml')), 2)
+    """
+    for _ in range(n):
+        yield from plan_func
+
+
 print(f'leaving {__file__}...\n')


### PR DESCRIPTION
Several key changes were introduced in this PR (__tested__ at 6BM):

* All devices are initialized via functions and set to 'debug' mode by default
* A global switch, `mode`, is used to toggle between different mode
* Devices staging is bypassed with an empty dictionary
* Fly and step scan are merged into one simple plan
* Motor initial position is cached in a dictionary, and resume motor position is done manually via `resume_motors_position()`
* Two dictionaries are used to track the predefined functions and vars, hopefully, to alleviate potential namespace contamination issues

_Future_ development targets:

* Robust automated failure recovery
* Auto messaging for status update
* Global reinitialization function(s) 
